### PR TITLE
[feature][m]: add bulk export functionality to search_sql - refs #3

### DIFF
--- a/ckanext/bigquery/backend/bigquery.py
+++ b/ckanext/bigquery/backend/bigquery.py
@@ -19,12 +19,15 @@ class DatastoreBigQueryBackend(DatastoreBackend):
         self.enable_sql_search = toolkit.asbool(config.get('ckan.datastore.sqlsearch.enabled', True))
 
     def _get_engine(self):
-        # TODO: how do we want credentials to get passed in via config or env variable ??
-        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = config.get('ckanext.bigquery.google_cloud_credentials', None)
+        '''To be able to run google cloud bigquery/storage operations you need to setup your credentials.
+        
+        Follow https://cloud.google.com/docs/authentication/getting-started
+        '''
+        creds = config.get('ckanext.bigquery.google_cloud_credentials', None)
         read_only_creds = config.get('ckanext.bigquery.google_cloud_credentials_read_only', None)
         project = config.get('ckanext.bigquery.project', None)
         dataset = config.get('ckanext.bigquery.dataset', None)
-        self._engine = ckan2bq.Client(project, dataset, read_only_creds)
+        self._engine = ckan2bq.Client(project, dataset, creds, read_only_creds)
         return self._engine
 
     def _log_or_raise(self, message):

--- a/ckanext/bigquery/backend/bigquery.py
+++ b/ckanext/bigquery/backend/bigquery.py
@@ -21,9 +21,10 @@ class DatastoreBigQueryBackend(DatastoreBackend):
     def _get_engine(self):
         # TODO: how do we want credentials to get passed in via config or env variable ??
         os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = config.get('ckanext.bigquery.google_cloud_credentials', None)
+        read_only_creds = config.get('ckanext.bigquery.google_cloud_credentials_read_only', None)
         project = config.get('ckanext.bigquery.project', None)
         dataset = config.get('ckanext.bigquery.dataset', None)
-        self._engine = ckan2bq.Client(project, dataset)
+        self._engine = ckan2bq.Client(project, dataset, read_only_creds)
         return self._engine
 
     def _log_or_raise(self, message):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-bigquery
+google-cloud-storage

--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -102,7 +102,7 @@ class Client(object):
             # get temp table containing query result
             destination_table = sql_query_job.destination
             log.warning("destination table: {}".format(destination_table))
-            destination_urls = self.extract_table(destination_table, sql_initial)
+            destination_urls = self.extract_query_to_gcs(destination_table, sql_initial)
             log.warning("extract job result: {}".format(destination_urls))
             return {
                 "help":"https://demo.ckan.org/api/3/action/help_show?name=datastore_search_sql",
@@ -122,7 +122,16 @@ class Client(object):
                 }
 
     @retry.Retry(predicate=if_exception_type(exceptions.NotFound))
-    def extract_table(self, table_ref, sql):
+    def extract_query_to_gcs(self, table_ref, sql):
+        '''Take query results from temp table and extract to gcs bucket
+        
+        Parameters:
+        table_ref: temp table with the query results
+        sql: sql statement to get table name from
+
+        Returns:
+        res_destination_urls: gcs files public url(s) contain extracted query results
+        '''
         bucket_name = config.get('ckanext.bigquery.bucket', None)
         location = config.get('ckanext.bigquery.location', None)
         table_name = tables_in_query(sql)

--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -84,12 +84,7 @@ class Client(object):
         '''
         # limit the number of results to ckan.datastore.search.rows_max + 1
         # (the +1 is so that we know if the results went over the limit or not)
-        try:
-             # check rows_max parameter set in CKAN config,
-             # while testing as microlibrary (not as ckan ext) ckan is unknown
-            rows_max = int(config.get('ckan.datastore.search.rows_max', 32000))
-        except:
-            rows_max = 32000 # set default rows limit  
+        rows_max = int(config.get('ckan.datastore.search.rows_max', 32000))
         sql_initial = sql
         # limit the number of results to return by rows_max
         sql = 'SELECT * FROM ({0}) AS blah LIMIT {1} ;'.format(sql, rows_max+1)

--- a/test/test_ckan_to_bigquery.py
+++ b/test/test_ckan_to_bigquery.py
@@ -1,8 +1,8 @@
-import sys
-sys.path.insert(0, './src')
+#import sys
+#sys.path.insert(0, './src')
 import os
 
-import ckan_to_bigquery as ckan2bq
+from src import ckan_to_bigquery as ckan2bq
 from google.cloud.bigquery.schema import SchemaField
 
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '.bigquery_test_credentials.json'
@@ -252,6 +252,5 @@ class TestSearchSql:
     def test_search_limit_above_threshold(self):
         sql = 'SELECT * FROM %s LIMIT 1000000' % table_name
         out = client.search_sql(sql)
-        assert len(out['result']['records']) == 32000
         assert out['records_truncated'] == "true"
         assert out['gc_url'] != ''

--- a/test/test_ckan_to_bigquery.py
+++ b/test/test_ckan_to_bigquery.py
@@ -240,11 +240,18 @@ class TestSearchSql:
         out = client.search_sql(sql)
         assert len(out['result']['records']) == 223287
 
-    def test_search_limit(self):
+    def test_search_limit_under_threshold(self):
         # returns 32000 records,
         # ignoring the 'LIMIT 32100' in query because we specified limit to 32000 
         # in ckan config 'ckan.datastore.search.rows_max'
         # but limit is more than rows_max so rows_max=32000 wins
-        sql = 'SELECT * FROM %s LIMIT 32100' % table_name
+        sql = 'SELECT * FROM %s LIMIT 10' % table_name
+        out = client.search_sql(sql)
+        assert len(out['result']['records']) == 10
+    
+    def test_search_limit_above_threshold(self):
+        sql = 'SELECT * FROM %s LIMIT 1000000' % table_name
         out = client.search_sql(sql)
         assert len(out['result']['records']) == 32000
+        assert out['records_truncated'] == "true"
+        assert out['gc_url'] != ''

--- a/test/test_ckan_to_bigquery.py
+++ b/test/test_ckan_to_bigquery.py
@@ -1,15 +1,19 @@
-#import sys
-#sys.path.insert(0, './src')
+import sys
+sys.path.insert(0, './src')
 import os
 
-from src import ckan_to_bigquery as ckan2bq
+import ckan_to_bigquery as ckan2bq
 from google.cloud.bigquery.schema import SchemaField
 
-os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '.bigquery_test_credentials.json'
+def script_path():
+    return os.path.dirname(os.path.abspath(__file__))
+
+creds = script_path() + '/google.json'
+read_only_creds = script_path() + '/google_readonly.json'
 
 project_id = 'bigquerytest-271707'
 dataset = 'nhs_production'
-client = ckan2bq.Client(project_id, dataset)
+client = ckan2bq.Client(project_id, dataset, creds, read_only_creds)
 
 table_name = 'EPD_201401'
 
@@ -253,4 +257,4 @@ class TestSearchSql:
         sql = 'SELECT * FROM %s LIMIT 1000000' % table_name
         out = client.search_sql(sql)
         assert out['records_truncated'] == "true"
-        assert out['gc_url'] != ''
+        assert out['gc_urls'] != []


### PR DESCRIPTION
This PR is about to add Bulk export / query from the API (datastore search_sql) ability.
Normal default API response up to e.g. Xk (`ckan.datastore.search.rows_max`), above that switches to response that points to output files that you can download.
Added method `extract_table` that is transfers query results stored in temp table into gc bucket.
The second new method `retrieve_gc_urls` returns gc bucket file(s) URLs where the query results where stored.
Added separate `google_cloud_credentials` for bulk export process, otherwise, the query is running with read_only creds.