### PR TITLE
[bug][m]: add retry on BadGetaway error from server

### DIFF
--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -105,6 +105,8 @@ class Client(object):
                     }
                 }
 
+    @retry.Retry(predicate=if_exception_type(exceptions.BadGateway, exceptions.InternalServerError, exceptions.ServiceUnavailable,
+                                             exceptions.GatewayTimeout), initial=1.0, maximum=60.0, multiplier=2.0, deadline=120.0)
     def write_query_result_to_table(self, sql_initial):
         sql_query_job = self.bqclient.query(sql_initial, job_config=self.job_config)
         # get temp table containing query result

--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -105,7 +105,6 @@ class Client(object):
                     }
                 }
 
-    @retry.Retry(predicate=if_exception_type(exceptions.ServerError))
     def write_query_result_to_table(self, sql_initial):
         sql_query_job = self.bqclient.query(sql_initial, job_config=self.job_config)
         # get temp table containing query result
@@ -120,7 +119,9 @@ class Client(object):
             "gc_urls": destination_urls
         }
 
-    @retry.Retry(predicate=if_exception_type(exceptions.NotFound))
+    @retry.Retry(predicate=if_exception_type(exceptions.NotFound, exceptions.BadGateway, 
+                                             exceptions.InternalServerError, exceptions.ServiceUnavailable,
+                                             exceptions.GatewayTimeout))
     def extract_query_to_gcs(self, table_ref, sql):
         '''Take query results from temp table and extract to gcs bucket
         

--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -121,7 +121,7 @@ class Client(object):
 
     @retry.Retry(predicate=if_exception_type(exceptions.NotFound, exceptions.BadGateway, 
                                              exceptions.InternalServerError, exceptions.ServiceUnavailable,
-                                             exceptions.GatewayTimeout))
+                                             exceptions.GatewayTimeout), initial=1.0, maximum=60.0, multiplier=2.0, deadline=180.0)
     def extract_query_to_gcs(self, table_ref, sql):
         '''Take query results from temp table and extract to gcs bucket
         

--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -105,7 +105,7 @@ class Client(object):
                     }
                 }
 
-    @retry.Retry(predicate=if_exception_type(exceptions.BadGateway))
+    @retry.Retry(predicate=if_exception_type(exceptions.ServerError))
     def write_query_result_to_table(self, sql_initial):
         sql_query_job = self.bqclient.query(sql_initial, job_config=self.job_config)
         # get temp table containing query result


### PR DESCRIPTION
- extract "writing query result and export to gcs" code to `write_query_result_to_table` function

- add `retry` decorator to `write_query_result_to_table` function on `BadGateway` error returned from server