### PR TITLE
[ckan_to_bigquery.py] Do bulk export before processing records

### DIFF
--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -298,6 +298,9 @@ class Client(object):
         self.log_data['bigquery_job_id'] = query_job.job_id
         self.log_data['job_details'] = query_job._properties.get('statistics')
         records = []
+        
+        if rows.total_rows == rows_max + 1:
+            return self.bulk_export(sql_initial)
 
         # Convert large numbers to strings to avoid them being rounded of
         # in the browser
@@ -311,20 +314,16 @@ class Client(object):
             records.append(dict_row)
 
         self.log_data['bigquery_egress'] = sys.getsizeof(str(records))
-        # check if results truncated ...
-        if len(records) == rows_max + 1:
-           return self.bulk_export(sql_initial)
-        else:
-            self.create_egress_log()
-            # do normal
-            return {
-                    "help":"https://demo.ckan.org/api/3/action/help_show?name=datastore_search_sql",
-                    "success": "true",
-                    "result":{
-                        "records": records,
-                        "fields": []
-                    }
+        self.create_egress_log()
+        # do normal
+        return {
+                "help":"https://demo.ckan.org/api/3/action/help_show?name=datastore_search_sql",
+                "success": "true",
+                "result":{
+                    "records": records,
+                    "fields": []
                 }
+            }
 
     def search_sql(self, data_dict):
         # default is_bulk export value


### PR DESCRIPTION
Previously bulk export was happening after the records were processed which isn't required for bulk export. If the records are more than the max_limit the bulk_export should be called from there instead of after the `records` list getting created.

So bumped that logic up before record processing and retrieved total rows from the bigquery return object instead of checking the length of the `records` list after records are created.