### PR TITLE
[ckan_to_bigquery.py] Return the active resource in resource_show

### DIFF
--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -43,6 +43,8 @@ def resource_show(context, data_dict):
     model = context['model']
     name_or_id = data_dict.get("id") or _get_or_bust(data_dict, 'name_or_id')
     resource = model.Resource.get(name_or_id)
+    if resource and resource.state == 'deleted':
+        resource = model.Session.query(model.Resource).filter(model.Resource.name == name_or_id).filter( model.Resource.state == 'active').first()
     if not resource:
         raise NotFound
     pkg_dict = logic.get_action('package_show')(


### PR DESCRIPTION
Fixes: https://gitlab.com/datopian/core/support/-/issues/459

Fixes an issue reported by the client as resource_show is returning a deleted resource instead of the active one.
So first its going to check for the resource as its already checking and if that returns a deleted resource the query with  "WHERE state=active" is going to be executed.