### PR TITLE
Return bulk export result with history

### DIFF
--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -59,6 +59,7 @@ class Client(object):
             "include_total": include_total,
             "resource_id": data_dict['resource_id'],
             "fields": fields,
+            "records": results,
             "records_format": "objects",
             "_links": {
             "start": "/api/3/action/datastore_search?resource_id="+data_dict['resource_id'],

--- a/src/ckan_to_bigquery.py
+++ b/src/ckan_to_bigquery.py
@@ -1,4 +1,6 @@
 import os
+import base64
+import json
 
 from google.cloud import bigquery
 from api_tracker import tables_in_query
@@ -52,12 +54,12 @@ class Client(object):
             total = self.get_total_num_of_query_rows(fields, data_dict)
         else:
             total = len(results)
+        
         out = {
             "include_total": include_total,
             "resource_id": data_dict['resource_id'],
             "fields": fields,
             "records_format": "objects",
-            "records": results,
             "_links": {
             "start": "/api/3/action/datastore_search?resource_id="+data_dict['resource_id'],
             "next": "/api/3/action/datastore_search?offset=100&resource_id="+data_dict['resource_id']
@@ -205,20 +207,23 @@ class Client(object):
         rows_max = int(config.get('ckan.datastore.search.rows_max', 32000))
         sql_initial = sql
         # limit the number of results to return by rows_max
-        sql = 'SELECT * FROM ({0}) AS blah LIMIT {1} ;'.format(sql, rows_max+1)
+        sql = 'SELECT COUNT(*) AS total FROM ({0}) AS blah LIMIT {1} ;'.format(sql, rows_max+1)
         query_job = self.bqclient_readonly.query(sql, job_config=self.job_config)
         rows = query_job.result() 
-        records = [dict(row) for row in rows]
+        total_rows = dict(next(iter(rows)))['total']
         # check if results truncated ...
-        if len(records) == rows_max + 1:
+        if total_rows > rows_max:
            return self.bulk_export(sql_initial)
         else:
-            # do normal
+            sql = 'SELECT * FROM ({0}) AS blah LIMIT {1} ;'.format(sql_initial, rows_max+1)
+            query_job = self.bqclient_readonly.query(sql, job_config=self.job_config)
+            rows = query_job.result()
+            records = [dict(row) for row in rows]
             return {
                     "help":"https://demo.ckan.org/api/3/action/help_show?name=datastore_search_sql",
                     "success": "true",
-                    "result":{
-                        "records": records,
+                    "result": {
+                        "records": {},
                         "fields": []
                     }
                 }
@@ -234,23 +239,103 @@ class Client(object):
         else:
             log.warning("do standard search_sql")
             return self.search_sql_normal(data_dict['sql'])
+        
+    def _get_table_last_modified_time(self, table_id):
+        '''
+            Get the last modified time of a table
+        '''
+        query = '''
+            SELECT 
+            TIMESTAMP_MILLIS(last_modified_time) AS last_modified_time 
+            FROM `{0}.{1}.__TABLES__`
+            WHERE table_id =  '{2}' ;
+            '''.format(self.project_id, self.dataset, table_id)
+        query_job = self.bqclient.query(query, job_config=self.job_config)
+        rows = query_job.result()
+        last_modified_time = dict(next(iter(rows)))['last_modified_time']
+        return last_modified_time
+    
+    def _get_query_history(self, table_id, query, modified_time):
+        '''
+            Look up query history, return result if already exists
+        '''
+        query = """
+            SELECT * FROM `{0}.{1}._query_history_lookup` 
+            WHERE table_id = "{2}" 
+            AND query = "{3}" 
+            AND modified_time = "{4}"
+            """.format(
+            self.project_id, self.dataset, table_id, query, modified_time
+        )
+        query_job = self.bqclient.query(query, job_config=self.job_config)
+        rows = query_job.result()
+        records = [dict(row) for row in rows]
+        return records
+    
+    def _insert_query_into_history(self, table_id, query, modified_time, result):
+        query = '''
+            INSERT INTO `{0}.{1}._query_history_lookup` (query, modified_time, created_at, table_id, result) 
+            VALUES ('{2}', '{3}', CURRENT_TIMESTAMP(), '{4}', '{5}')
+            '''.format(self.project_id, self.dataset, query, modified_time, table_id, result)
+        query_job = self.bqclient.query(query, job_config=self.job_config)
+        query_job.result()
+        return query_job
+
+    def _query_history_lookup(self, sql_initial):
+        '''
+            Get query history if available
+        '''
+
+        table_ref = self.bqclient.dataset(self.dataset).table('_query_history_lookup')
+        table = bigquery.Table(table_ref)
+        table.schema = [
+            bigquery.SchemaField('query', 'STRING', mode='REQUIRED'),
+            bigquery.SchemaField('modified_time', 'TIMESTAMP'),
+            bigquery.SchemaField('created_at', 'TIMESTAMP'),
+            bigquery.SchemaField('table_id', 'STRING'),
+            bigquery.SchemaField('result', 'STRING'),
+        ]
+        table = self.bqclient.create_table(table, exists_ok=True)
+
+        # Get the table id
+        table_id = tables_in_query(sql_initial).replace('`', '')
+
+        # Convert the sql to base64
+        encoded_query = base64.b64encode(sql_initial)
+        table_modified_time = self._get_table_last_modified_time(table_id)
+        query_history = self._get_query_history(table_id, encoded_query, table_modified_time)
+        return query_history, encoded_query, table_modified_time
+
 
     def bulk_export(self, sql_initial):
-        try:
-            sql_query_job = self.bqclient.query(sql_initial, job_config=self.job_config)
-            # get temp table containing query result
-            destination_table = sql_query_job.destination
-            log.warning("destination table: {}".format(destination_table))
-            destination_urls = self.extract_query_to_gcs(destination_table, sql_initial)
-            log.warning("extract job result: {}".format(destination_urls))
-            return {
-                "help":"https://demo.ckan.org/api/3/action/help_show?name=datastore_search_sql",
-                "success": "true",
-                "records_truncated": "true",
-                "gc_urls": destination_urls
-            }
-        except Exception as ex:
-            log.error("Error: {}".format(str(ex)))
+        query_history, encoded_query, table_modified_time = self._query_history_lookup(sql_initial)
+        result = {
+            "help": "https://demo.ckan.org/api/3/action/help_show?name=datastore_search_sql",
+            "success": "true",
+            "records_truncated": "true",
+            "gc_urls": []
+        }
+        if query_history:
+            log.warning("History Exist: returning datastore query result from history")
+            result['gc_urls'] = json.loads(query_history[0]['result'])
+            return result
+        else:
+            try:
+                sql_query_job = self.bqclient.query(sql_initial, job_config=self.job_config)
+                # get temp table containing query result
+                destination_table = sql_query_job.destination
+                log.warning("destination table: {}".format(destination_table))
+                destination_urls = self.extract_query_to_gcs(destination_table, sql_initial)
+                log.warning("extract job result: {}".format(destination_urls))
+
+                # insert query into history for future use
+                table_id = tables_in_query(sql_initial).replace('`', '')
+                self._insert_query_into_history(table_id, encoded_query, table_modified_time, json.dumps(destination_urls))
+                result['gc_urls'] = destination_urls
+                return result
+            
+            except Exception as ex:
+                log.error("Error: {}".format(str(ex)))
 
     @retry.Retry(predicate=if_exception_type(exceptions.NotFound))
     def extract_query_to_gcs(self, table_ref, sql):


### PR DESCRIPTION

1. Create a lookup table `_query_history_lookup` in BigQuery to store query history.
2. Store encoded queries and table last modified timestamps in the query history lookup table.
3. Create a history entry if the query does not exist in the lookup table. If it exists, return the result from the history.


If the query history exists, the current response time is ~6 seconds, but returning directly from BigQuery takes an additional 5 seconds due to the extra logic we added.